### PR TITLE
Canonical PHP style

### DIFF
--- a/Abwasser.php
+++ b/Abwasser.php
@@ -1,5 +1,3 @@
 <?php
 
-echo "Abwasser"
-
-?>
+echo "Abwasser";


### PR DESCRIPTION
It is canonical in a pure PHP file to not close the php tag itself (because reasons)

Beyond that php is a dumb language and as such requires semicolons ... sort of.
