### PR TITLE
Fix Chocolate Espresso

### DIFF
--- a/Chocolate_Espresso.mm
+++ b/Chocolate_Espresso.mm
@@ -1,4 +1,8 @@
+#import <Foundation/Foundation.h>
+
 // die dunkle Variante von swift
-int main() {
-    NSLog(@"Chocolate Espresso - 1,00€");
+int main()
+{
+    printf("Chocolate Espresso - 1,00€\n");
 }
+


### PR DESCRIPTION
`NSLog` adds additional datetime info. And both that and `printf` aren't found without
importing Foundation.
